### PR TITLE
Fix MacOS builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -92,7 +92,7 @@ library = env.SharedLibrary(
 )
 
 prefix=""
-if env["platform"] == "linux":
+if env["platform"] == "linux" or env["platform"] == "macos":
     prefix = "lib"
 
 


### PR DESCRIPTION
The MacOS binaries are prefixed with `lib` similarly to the Linux binaries, so this makes the prefix step also apply to MacOS.